### PR TITLE
CON-1695: Increase post-promotion recovery timeout to 120s

### DIFF
--- a/postgres-appliance/scripts/on_role_change.sh
+++ b/postgres-appliance/scripts/on_role_change.sh
@@ -8,7 +8,9 @@ shift
 
 readonly dbname=postgres
 if [[ "${*: -3:1}" == "on_role_change" && "${*: -2:1}" == "master" ]]; then
-    num=30  # wait 30 seconds for end of recovery
+    # Large clusters may need more than 30s to finish recovery after promotion,
+    # which caused post_init.sh (and thus extension upgrades like timescaledb) to be skipped silently.
+    num=120
     while  [[ $((num--)) -gt 0 ]]; do
         if [[ "$(psql -d $dbname -tAc 'SELECT pg_catalog.pg_is_in_recovery()')" == "f" ]]; then
             vacuumdb -aZ > /dev/null 2>&1 &


### PR DESCRIPTION
## Summary
- Increases the recovery wait timeout in `on_role_change.sh` from 30s to 120s
- Large clusters can take longer than 30s to exit recovery after a switchover, which caused `post_init.sh` to never run — silently skipping extension upgrades (e.g. `ALTER EXTENSION timescaledb UPDATE`)

## Test plan
- [ ] Verify on a large cluster that switchover now triggers `post_init.sh` and the timescaledb extension is upgraded
- [ ] Verify on a small cluster that behavior is unchanged (just waits less than the new 120s cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)